### PR TITLE
Bump version of dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           sudo curl -fsSLo /usr/share/keyrings/intel-sgx-deb.asc https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key
           echo "deb [arch=amd64 signed-by=/usr/share/keyrings/intel-sgx-deb.asc] https://download.01.org/intel-sgx/sgx_repo/ubuntu noble main" | sudo tee /etc/apt/sources.list.d/intel-sgx.list
-          sudo apt-get update && sudo apt-get install -y tpm2-tools libtss2-dev libtdx-attest=1.24.100.2-noble1 libtdx-attest-dev=1.24.100.2-noble1
+          sudo apt-get update && sudo apt-get install -y tpm2-tools libtss2-dev libtdx-attest=1.26.100.1-noble1 libtdx-attest-dev=1.26.100.1-noble1
 
       - name: Install Rust toolchain and components
         if: steps.cargo-cache.outputs.cache-hit != 'true'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,9 +97,9 @@ dependencies = [
 
 [[package]]
 name = "asn1-rs"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
 dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2361,9 +2361,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "indexmap",
  "itoa",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1427,9 +1427,9 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "lru-slab"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,7 +182,7 @@ dependencies = [
 
 [[package]]
 name = "azure_cvm"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "base64",
  "jose-jwk",
@@ -1439,7 +1439,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "maa_client"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "base64",
  "hex",
@@ -1685,7 +1685,7 @@ dependencies = [
 
 [[package]]
 name = "pccs_client"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "hex",
  "reqwest",
@@ -1987,7 +1987,7 @@ checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "ratls"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "const-oid 0.9.6",
  "der",
@@ -2398,7 +2398,7 @@ dependencies = [
 
 [[package]]
 name = "sev_quote"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "asn1-rs",
  "env_logger",
@@ -2416,7 +2416,7 @@ dependencies = [
 
 [[package]]
 name = "sgx_pck_extension"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "asn1",
  "asn1-rs",
@@ -2426,7 +2426,7 @@ dependencies = [
 
 [[package]]
 name = "sgx_quote"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "chrono",
  "env_logger",
@@ -2617,7 +2617,7 @@ dependencies = [
 
 [[package]]
 name = "tdx_quote"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "env_logger",
  "hex",
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "tee_attestation"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "azure_cvm",
  "env_logger",
@@ -2789,7 +2789,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tls-cert"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "rustls",
  "rustls-pki-types",
@@ -2889,7 +2889,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tpm_quote"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "env_logger",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2054,9 +2054,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1614,15 +1614,14 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl"
-version = "0.10.78"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
  "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -1655,9 +1654,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.114"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.0.0"
+version = "2.0.1"
 edition = "2024"
 license = "BUSL-1.1" # "Business Source License 1.1"
 license-file = "LICENSE"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Collection of Rust libraries for local and remote attestation of Intel SGX/TDX, 
 | [maa_client](crate/maa_client/) | High-level API for Microsoft Azure Attestation service |
 | [pccs_client](crate/pccs_client/) | High-level API for Intel Provisioning Certification Cache Service |
 | [ratls](crate/ratls/) | Remote Attestation integration with Transport Layer Security |
-| [sev_quote](crate/sev_quote/) | Generation and verification of AMND SEV-SNP attestation report |
+| [sev_quote](crate/sev_quote/) | Generation and verification of AMD SEV-SNP attestation report |
 | [sgx_pck_extension](crate/sgx_pck_extension/) | Parsing of Intel SGX Provisioning Certification Key ASN.1 extension |
 | [sgx_quote](crate/sgx_quote/) | Generation and verification of Intel SGX attestation report |
 | [tdx_quote](crate/tdx_quote/) | Generation and verification of Intel TDX attestation report |


### PR DESCRIPTION
## Added

- Bump version of crates to 2.0.1

## Fixed

- Bump `openssl` crate to 0.10.80
- Bump `asn1-rs` crate to 0.7.2
- Bump `serde_json` crate to 1.0.50
- Bump `reqwest` crate to 0.13.4
- Bump `log` crate to 0.4.30